### PR TITLE
Update npm-global-without-sudo-linux.md

### DIFF
--- a/npm-global-without-sudo-linux.md
+++ b/npm-global-without-sudo-linux.md
@@ -20,7 +20,7 @@ NPM_PACKAGES="$HOME/.npm-packages"
 3. Indicate to `npm` where to store your globally installed package. In
    your `$HOME/.npmrc` file add:
 ```
-prefix="$HOME/.npm-packages"
+prefix=${HOME}/.npm-packages
 ```
 
 4. Ensure `node` will find them. Add the following to your


### PR DESCRIPTION
Updated prefix syntax for .npmrc per docs here:https://www.npmjs.org/doc/files/npmrc.html
Not sure if it is a change on the npm side, but with npm 1.4.3, the current syntax was creating a directory called "$HOME". instead of accessing environment vars.

PS - Thank you for making this and all you do.
