### PR TITLE
Updating with OSX-specific instructions

### DIFF
--- a/npm-global-without-sudo-linux.md
+++ b/npm-global-without-sudo-linux.md
@@ -1,4 +1,4 @@
-# Install npm packages globally on Linux without sudo
+# Install npm packages globally on Linux or OSX without sudo
 
 npm installs packages locally within each of your projects by default. You
 can also install packages globally (e.g. `npm install -g <package>`). However
@@ -47,3 +47,11 @@ MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
 Inspired from this [answer on StackOverflow](http://stackoverflow.com/a/13021677).
 
 Check out [npm-g_nosudo](https://github.com/glenpike/npm-g_nosudo) for doing the above steps automagically.
+
+NOTE: if you are running OSX, the `.bashrc` file may not yet exist, and Terminal will be obtaining its environment 
+parameters from another file, such as `.profile` or `.bash_profile`. These files also reside in the user's home folder.
+In this case, simply adding the following line to them will instruct Terminal to also load the `.bashrc` file:
+
+```sh
+source ~/.bashrc
+```


### PR DESCRIPTION
Tested on OSX 10.9.5.
These instructions will soon be referenced from this tutorial page:  http://yeoman.io/codelab/setup.html.
The update for Mac users would be helpful as many are running into difficulties with permissions errors, and the tutorial page has been recommending using 'sudo' as a work-around.
The plan for the tutorial page is to recommend against using 'sudo' as the work-around, and instead point them to this page for the proper solution.
