### PR TITLE
Aliases aren't expanded in scripts by default.

### DIFF
--- a/how-not-to-rm-yourself.md
+++ b/how-not-to-rm-yourself.md
@@ -22,7 +22,7 @@ $ trash unicorn.png rainbow.png
 
 Even though you don't use `rm` directly, external scripts most likely will. There are some things you can do to safeguard this:
 
-- Alias `rm` to its interactive mode `rm -i` and set `shopt -s expand_aliases` in your `$BASH_ENV`. This will force you to step through what it's trying to delete.
+- Alias `rm` to its interactive mode `rm -i` and set `shopt -s expand_aliases` and source your `.bashrc` in `$BASH_ENV`. This will force you to step through what it's trying to delete.
 
 - Install `coreutils` which includes a newer version of `rm` with the flag `--preserve-root` which is enabled by default and will prevent you from removing root.
 	OS X: `brew install coreutils`

--- a/how-not-to-rm-yourself.md
+++ b/how-not-to-rm-yourself.md
@@ -22,7 +22,26 @@ $ trash unicorn.png rainbow.png
 
 Even though you don't use `rm` directly, external scripts most likely will. There are some things you can do to safeguard this:
 
-- Alias `rm` to its interactive mode `rm -i` and set `shopt -s expand_aliases` and source your `.bashrc` in `$BASH_ENV`. This will force you to step through what it's trying to delete.
+- Alias `rm` to its interactive mode `rm -i`:
+
+ If you only want to alias `rm` in your interactive shell (and not in scripts), just add `alias rm='rm -i'` to your `.bashrc` or `.zshrc`.
+
+	If you want to force scripts to use `rm -i` as well, follow these steps depending on which shell you're using:
+
+ **bash**:
+   * Add `alias rm='rm -i'` to your `.bashrc`.
+    
+   * Create a file called `.bashenv` in your home directory with `shopt -s expand_aliases` and `source .bashrc`.
+   
+   * In your `.bashrc`, add `export BASH_ENV='~/.bashenv'`.
+   
+ **zsh**:
+
+   If you use zsh and want `rm` to be aliased in bash scripts, zsh scripts _and_ your own interactive z shell, we have to jump through some more hoops:
+  * Create a file called `.common_profile` in your home directory with `alias rm='rm -i'`
+  * Create a file called `.bashenv` in your home directory with `source ~/.common_profile` and `shopt -s expand_aliases`.
+  * Create a file called `.zshenv` in your home directory alongside `.bashenv` and add `source ~/.common_profile`.
+  * Finally, in your `.zshrc` add `source ~/.common_profile` and `export BASH_ENV='~/.bashenv'`. Your `.common_profile`, `.bashenv`, `.zshenv` and `.zshrc` should end up looking like [this](https://gist.github.com/andbroby/958c6b4259290d4c884c).
 
 - Install `coreutils` which includes a newer version of `rm` with the flag `--preserve-root` which is enabled by default and will prevent you from removing root.
 	OS X: `brew install coreutils`

--- a/how-not-to-rm-yourself.md
+++ b/how-not-to-rm-yourself.md
@@ -22,7 +22,7 @@ $ trash unicorn.png rainbow.png
 
 Even though you don't use `rm` directly, external scripts most likely will. There are some things you can do to safeguard this:
 
-- Alias `rm` to its interactive mode, which will force you to step through what it's trying to delete: `alias rm='rm -i'`
+- Alias `rm` to its interactive mode `rm -i` and set `shopt -s expand_aliases` in your `$BASH_ENV`. This will force you to step through what it's trying to delete.
 
 - Install `coreutils` which includes a newer version of `rm` with the flag `--preserve-root` which is enabled by default and will prevent you from removing root.
 	OS X: `brew install coreutils`


### PR DESCRIPTION
See: https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html

Non-interactive shells don't expand the alias so if you want scripts to use rm -i you'll have to enable it in your BASH_ENV.