### PR TITLE
Fix typo in npm-global-without-sudo.md

### DIFF
--- a/npm-global-without-sudo.md
+++ b/npm-global-without-sudo.md
@@ -4,7 +4,7 @@
 
 Here is a way to install packages globally for a given user.
 
-###### 1. Create a directory for globally packages
+###### 1. Create a directory for global packages
 
 ```sh
 mkdir "${HOME}/.npm-packages"


### PR DESCRIPTION
as suggested in title

`globally packages` -> `global packages`