### PR TITLE
Missing `NODE_PATH` line

### DIFF
--- a/npm-global-without-sudo.md
+++ b/npm-global-without-sudo.md
@@ -26,6 +26,9 @@ PATH="$NPM_PACKAGES/bin:$PATH"
 # Unset manpath so we can inherit from /etc/manpath via the `manpath` command
 unset MANPATH # delete if you already modified MANPATH elsewhere in your config
 export MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
+
+# Tell Node about these packages
+NODE_PATH="$NPM_PACKAGES/lib/node_modules:$NODE_PATH"
 ```
 
 -


### PR DESCRIPTION
This addition matches the original SO answer [http://stackoverflow.com/questions/10081293/install-npm-into-home-directory-with-distribution-nodejs-package-ubuntu/13021677](here), which was necessary to actually get it working.