### PR TITLE
Add step on "Run Docker commands without sudo"

### DIFF
--- a/docker-without-sudo.md
+++ b/docker-without-sudo.md
@@ -25,3 +25,7 @@ If you are on Ubuntu 14.04-15.10, use `docker.io` instead:
 ```console
 $ sudo service docker.io restart
 ```
+
+##### 4. Log out and in again
+
+To ensure bash updates your groups


### PR DESCRIPTION
The guide wasn't working for me because I had to log out and in again and it was because I had to start another bash process so my groups are updated, this was the output of the `groups` command

```
me@my-vps:~$ groups
me sudo
me@my-vps:~$ groups me
me : me sudo docker
```