### PR TITLE
Add support for fish shell in the npm global guide

### DIFF
--- a/npm-global-without-sudo.md
+++ b/npm-global-without-sudo.md
@@ -30,15 +30,16 @@ unset MANPATH # delete if you already modified MANPATH elsewhere in your config
 export MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
 ```
 
-If you are on `fish` within `~/.config/fish/config.fish`  
+If you're using `fish`, add the following to `~/.config/fish/config.fish`:
 
 ```sh
- set NPM_PACKAGES "$HOME/.npm-packages"                                                                                                                                                        
- set PATH $NPM_PACKAGES/bin $PATH                                                                                                                                                              
-                                                                                                                                                                                               
- # Unset manpath so we can inherit from /etc/manpath via the `manpath` command                                                                                                                 
- set -e MANPATH                                                                                                                                                                                
- set MANPATH $NPM_PACKAGES/share/man $MANPATH     
+set NPM_PACKAGES "$HOME/.npm-packages"
+
+set PATH $NPM_PACKAGES/bin $PATH
+
+# Unset manpath so we can inherit from /etc/manpath via the `manpath` command
+set -e MANPATH
+set MANPATH $NPM_PACKAGES/share/man $MANPATH  
 ```
 
 ---

--- a/npm-global-without-sudo.md
+++ b/npm-global-without-sudo.md
@@ -30,6 +30,17 @@ unset MANPATH # delete if you already modified MANPATH elsewhere in your config
 export MANPATH="$NPM_PACKAGES/share/man:$(manpath)"
 ```
 
+If you are on `fish` within `~/.config/fish/config.fish`  
+
+```sh
+ set NPM_PACKAGES "$HOME/.npm-packages"                                                                                                                                                        
+ set PATH $NPM_PACKAGES/bin $PATH                                                                                                                                                              
+                                                                                                                                                                                               
+ # Unset manpath so we can inherit from /etc/manpath via the `manpath` command                                                                                                                 
+ set -e MANPATH                                                                                                                                                                                
+ set MANPATH $NPM_PACKAGES/share/man $MANPATH     
+```
+
 ---
 
 Check out [`npm-g_nosudo`](https://github.com/glenpike/npm-g_nosudo) for doing the above steps automagically


### PR DESCRIPTION
Add instruction on how support npm global without sudo under fish shell.