### PR TITLE
Append to $PATH, not prepend, in the npm global guide

### DIFF
--- a/npm-global-without-sudo.md
+++ b/npm-global-without-sudo.md
@@ -23,7 +23,7 @@ Add the following to your `.bashrc`/`.zshrc`:
 ```sh
 NPM_PACKAGES="${HOME}/.npm-packages"
 
-export PATH="$NPM_PACKAGES/bin:$PATH"
+export PATH="$PATH:$NPM_PACKAGES/bin"
 
 # Unset manpath so we can inherit from /etc/manpath via the `manpath` command
 unset MANPATH # delete if you already modified MANPATH elsewhere in your config


### PR DESCRIPTION
Prepending to $PATH implies binaries in the added directory will take precedence ('overwrite') those in $PATH already. More often than not, such behavior is not desired and may even be a dangerous vulnerability. Especially in the case of untrusted packages from npm.