### PR TITLE
Add step to docker-without-sudo guide

### DIFF
--- a/docker-without-sudo.md
+++ b/docker-without-sudo.md
@@ -25,3 +25,7 @@ If you are on Ubuntu 14.04-15.10, use `docker.io` instead:
 ```console
 $ sudo service docker.io restart
 ```
+
+##### 4. Log out and log back in
+
+This last step is necessary in order to re-evaluate group membership. 


### PR DESCRIPTION
After the `docker` group has been added to a user, it is necessary to log out and than log in again for the new membership to take effect.