### PR TITLE
Change the context from Docker Desktop to Engine

### DIFF
--- a/docker-without-sudo.md
+++ b/docker-without-sudo.md
@@ -27,3 +27,11 @@ If you are on Ubuntu 14.04-15.10, use `docker.io` instead:
 ```console
 $ sudo service docker.io restart
 ```
+#### 4. Change the context from Docker Desktop to Engine
+If you installed Docker Desktop first, then removed it and installed the Docker Engine, you may need to switch the Docker context with this command:
+
+$ docker context use default
+
+Because Docker Desktop switches context before startups and shutdowns not to interfere Docker Engine. So context might be kept incorrectly after removing Docker Desktop. A related article: https://www.howtogeek.com/devops/how-to-troubleshoot-cannot-connect-to-the-docker-daemon-errors/
+
+https://stackoverflow.com/questions/73671461/docker-not-working-without-sudo-in-ubuntu-22-04

--- a/docker-without-sudo.md
+++ b/docker-without-sudo.md
@@ -27,10 +27,14 @@ If you are on Ubuntu 14.04-15.10, use `docker.io` instead:
 ```console
 $ sudo service docker.io restart
 ```
+
 #### 4. Change the context from Docker Desktop to Engine
+
 If you installed Docker Desktop first, then removed it and installed the Docker Engine, you may need to switch the Docker context with this command:
 
+```console
 $ docker context use default
+```
 
 Because Docker Desktop switches context before startups and shutdowns not to interfere Docker Engine. So context might be kept incorrectly after removing Docker Desktop. A related article: https://www.howtogeek.com/devops/how-to-troubleshoot-cannot-connect-to-the-docker-daemon-errors/
 


### PR DESCRIPTION
This command is useful when Docker Desktop has been instaled previously and the steps to remove the command "SUDO" does not work.